### PR TITLE
Modifying log contents in spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
@@ -92,7 +92,7 @@ public class WebServerPortFileWriter implements ApplicationListener<WebServerIni
 			portFile.deleteOnExit();
 		}
 		catch (Exception ex) {
-			logger.warn(LogMessage.format("Cannot create port file %s", this.file));
+			logger.warn(LogMessage.format("Cannot create port file %s", this.file), ex);
 		}
 	}
 


### PR DESCRIPTION
The log message should be updated to include the exception 'ex' to provide more context about why the port file couldn't be created. The current log message already includes 'this.file', which likely provides the necessary information about the file location. The event object is not directly relevant to this specific error message.


Created by Patchwork.